### PR TITLE
Fix crash when android id is shorter than 16

### DIFF
--- a/lib/src/main/java/com/github/gfx/util/encrypt/Encryption.java
+++ b/lib/src/main/java/com/github/gfx/util/encrypt/Encryption.java
@@ -45,9 +45,9 @@ public class Encryption {
         assert packageDigest.length == KEY_LENGTH;
 
         for (int i = 0; i < privateKey.length; i++) {
-            privateKey[i] ^= packageDigest[i];
+            packageDigest[i] ^= privateKey[i];
         }
-        return privateKey;
+        return packageDigest;
     }
 
     private static byte[] md5(byte[] value) {


### PR DESCRIPTION
# Issue

https://github.com/gfx/Android-EncryptUtils/issues/2
# Solution

Length of packageDiagest is allways 16.
So, bring result of XOR into packageDigest and return it.
